### PR TITLE
fix #1: warn if use reference to a struct field inside of a range loop

### DIFF
--- a/scopelint/lint.go
+++ b/scopelint/lint.go
@@ -151,6 +151,14 @@ CGS_LOOP:
 					ref := ""
 					n.errorf(ident, 1, n.Ignore, link(ref), category("range-scope"), "Using a reference for the variable on range scope %q", ident.Name)
 				}
+			case *ast.SelectorExpr:
+				switch x := ident.X.(type) {
+				case *ast.Ident:
+					if _, unsafe := n.UnsafeObjects[x.Obj]; unsafe {
+						ref := ""
+						n.errorf(ident, 1, n.Ignore, link(ref), category("range-scope"), "Using a reference for the variable on range scope %q", x.Name)
+					}
+				}
 			}
 		}
 

--- a/scopelint/lint_test.go
+++ b/scopelint/lint_test.go
@@ -231,3 +231,21 @@ func TestSomething(t *testing.T) {
 		})
 	})
 }
+
+func TestLint_RangeLoop_ReferenceForStructField(t *testing.T) {
+	t.Run("#1: reference for a struct field", func(t *testing.T) {
+		l := new(Linter)
+		problems, err := l.Lint("mypkg/mypkg.go", []byte(`package main
+
+func factory() (out []*int) {
+	for _, v := range make([]struct{ Field int }, 1) {
+		out = append(out, &v.Field)
+	}
+	return out
+}`))
+		require.NoError(t, err)
+		if assert.Len(t, problems, 1) {
+			assert.Equal(t, "Using a reference for the variable on range scope \"v\"", problems[0].Text)
+		}
+	})
+}


### PR DESCRIPTION
Fix #1 - show warning if using the reference to a struct field inside of a range loop.