### PR TITLE
fix: never report `_` as the proglem

### DIFF
--- a/scopelint/lint.go
+++ b/scopelint/lint.go
@@ -136,10 +136,12 @@ CGS_LOOP:
 		// Memory variables declarated in range statement
 		switch k := typedNode.Key.(type) {
 		case *ast.Ident:
+			if typedNode.Key.(*ast.Ident).String() == "_" {break;}
 			n.UnsafeObjects[k.Obj] = 0
 		}
 		switch v := typedNode.Value.(type) {
 		case *ast.Ident:
+			if typedNode.Key.(*ast.Ident).String() == "_" {break;}
 			n.UnsafeObjects[v.Obj] = 0
 		}
 


### PR DESCRIPTION
If we write code like this: 
`for _ = range time.Tick(time.Second * 10) {`

Actually we don't care whatever the key is. But scopelint will fail the check. I think it is a false positive.
One way to solve it is pass the check if the key or value in rage is "_".
`
if typedNode.Key.(*ast.Ident).String() == "_" {break;}
`
#15 